### PR TITLE
Fix double evaluation in PROC_WAIT_FOR and allow infinite process recursion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*
+!*.cpp
+!*.h
+!*.md
+!*.simcpp
+!.gitignore
+!Makefile

--- a/simcpp.h
+++ b/simcpp.h
@@ -45,7 +45,7 @@ public:
   shared_ptr<Process> run_process(shared_ptr<Process> p);
 
   template <class T, class... Args>
-  shared_ptr<Process> start_process(Args &&... args) {
+  shared_ptr<Process> start_process(Args &&...args) {
     return run_process(std::make_shared<T>(shared_from_this(), args...));
   }
 

--- a/simcpp.h
+++ b/simcpp.h
@@ -132,7 +132,7 @@ void Process::resume() {
 }
 
 shared_ptr<Event> Simulation::schedule(shared_ptr<Event> e, double delay) {
-  this->events.emplace(QueuedEvent(this->now + delay, id_counter++, e));
+  this->events.emplace(this->now + delay, id_counter++, e);
   return e;
 }
 

--- a/simcpp.h
+++ b/simcpp.h
@@ -8,8 +8,7 @@
 
 #define PROC_WAIT_FOR(event)                                                   \
   do {                                                                         \
-    if (!event->is_triggered()) {                                              \
-      event->add_handler(shared_from_this());                                  \
+    if ((event)->add_handler(shared_from_this())) {                            \
       PT_YIELD();                                                              \
     }                                                                          \
   } while (0)
@@ -91,7 +90,15 @@ public:
   Event(shared_ptr<Simulation> sim)
       : listeners(new vector<shared_ptr<Process>>()), sim(sim) {}
 
-  void add_handler(shared_ptr<Process> p) { listeners->push_back(p); }
+  bool add_handler(shared_ptr<Process> p) {
+    if (is_processed()) {
+      return false;
+    }
+
+    listeners->push_back(p);
+    return true;
+  }
+
   bool is_processed() { return this->listeners == nullptr; }
   int get_value() { return this->value; }
   void fire();

--- a/simcpp.h
+++ b/simcpp.h
@@ -172,7 +172,9 @@ void Event::fire() {
 }
 
 shared_ptr<Process> Simulation::run_process(shared_ptr<Process> p) {
-  p->resume();
+  auto ev = std::make_shared<Event>(shared_from_this());
+  ev->add_handler(p);
+  this->schedule(ev);
   return p;
 }
 


### PR DESCRIPTION
This pull request fixes two problems.

The `PROC_WAIT_FOR` macro evaluates `event` twice. This can be bad in certain situations, e.g. creating two timeout events instead of one (but it can have much worse effects). I changed `Event::add_handler` to return `true` when the event is not handled yet and used the return value in the macro to decide whether to yield.

`Simulation::start_process` and `Simulation::run_process` immediately execute the process. When new processes are created recursively, the stack thus grows infintely. Because of this, I could only create about 20 000 recursive processes. By scheduling an event to run the processes, the stack does not grow infinitely, since each process is started from an invocation of `Simulation::step`.

Further possible changes I can do if you want them:
- Personally, I do not like the redundant uses of `this` all over the place, remove them
- If simcpp is used in a project with multiple compilation units, the current header file leads to multiple definition errors - three options:
  1. Mark all methods defined outside classes as inline
  2. Move all methods definitions into the classes
  3. Move all methods defined outside classes into a cpp file
- Add `Event::succeed`, which would schedule an event to be fired immediately (and maybe `Event::fail`, but this would only set the value, not schedule anything)
- Change `Simulation::advance_to` to accept events
- Use an enum for `Event::value`