### PR TITLE
Rework events, refactor code, split into definition and declaration, fix AllOf / AnyOf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
-all: example-minimal example-twocars
-.PHONY: all
+HEADER=simcpp.h protothread.h
+EXE=example-minimal example-twocars
 
-example-minimal: example-minimal.cpp simcpp.h
-	g++ -Wall -std=c++11 example-minimal.cpp -o example-minimal
+.PHONY: clean
 
-example-twocars: example-twocars.cpp simcpp.h
-	g++ -Wall -std=c++11 example-twocars.cpp -o example-twocars
+all: $(EXE)
+
+%: %.cpp $(HEADER)
+	g++ -Wall -std=c++11 $< -o $@
+
+clean:
+	rm $(EXE)

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 HEADER=simcpp.h protothread.h
+SOURCE=simcpp.cpp
 EXE=example-minimal example-twocars
 
 .PHONY: clean
 
 all: $(EXE)
 
-%: %.cpp $(HEADER)
-	g++ -Wall -std=c++11 $< -o $@
+%: %.cpp $(HEADER) $(SOURCE)
+	g++ -Wall -std=c++11 $< $(SOURCE) -o $@
 
 clean:
 	rm $(EXE)

--- a/README.md
+++ b/README.md
@@ -5,14 +5,17 @@ Aims to be a port of [SimPy](https://simpy.readthedocs.io/en/latest/).
 Based on [Protothreads](http://dunkels.com/adam/pt/) and a [C++ port of Protothreads](https://github.com/benhoyt/protothreads-cpp).
 
 ## Minimal example
+
 ```c++
 #include "simcpp.h"
-using std::shared_ptr;
 
-class Car : public Process {
+class Car : public simcpp::Process {
 public:
-  Car(shared_ptr<Simulation> sim) : Process(sim) {}
-  virtual bool Run() {
+  explicit Car(simcpp::SimulationPtr sim) : Process(sim) {}
+
+  bool Run() override {
+    auto sim = this->sim.lock();
+
     PT_BEGIN();
 
     printf("Car running at %g.\n", sim->get_now());
@@ -24,7 +27,7 @@ public:
 };
 
 int main() {
-  auto sim = Simulation::create();
+  auto sim = simcpp::Simulation::create();
   sim->start_process<Car>();
   sim->run();
 

--- a/example-minimal.cpp
+++ b/example-minimal.cpp
@@ -1,14 +1,14 @@
-#include "simcpp.h"
-
 #include <cstdio>
+
+#include "simcpp.h"
 
 using std::shared_ptr;
 
 class Car : public simcpp::Process {
 public:
-  Car(simcpp::SimulationPtr sim) : Process(sim) {}
+  explicit Car(simcpp::SimulationPtr sim) : Process(sim) {}
 
-  virtual bool Run() override {
+  bool Run() override {
     PT_BEGIN();
 
     printf("Car running at %g.\n", sim->get_now());

--- a/example-minimal.cpp
+++ b/example-minimal.cpp
@@ -7,7 +7,8 @@ using std::shared_ptr;
 class Car : public Process {
 public:
   Car(shared_ptr<Simulation> sim) : Process(sim) {}
-  virtual bool Run() {
+
+  virtual bool Run() override {
     PT_BEGIN();
 
     printf("Car running at %g.\n", sim->get_now());

--- a/example-minimal.cpp
+++ b/example-minimal.cpp
@@ -6,7 +6,7 @@ using std::shared_ptr;
 
 class Car : public simcpp::Process {
 public:
-  Car(shared_ptr<simcpp::Simulation> sim) : Process(sim) {}
+  Car(simcpp::SimulationPtr sim) : Process(sim) {}
 
   virtual bool Run() override {
     PT_BEGIN();

--- a/example-minimal.cpp
+++ b/example-minimal.cpp
@@ -2,8 +2,6 @@
 
 #include "simcpp.h"
 
-using std::shared_ptr;
-
 class Car : public simcpp::Process {
 public:
   explicit Car(simcpp::SimulationPtr sim) : Process(sim) {}

--- a/example-minimal.cpp
+++ b/example-minimal.cpp
@@ -4,9 +4,9 @@
 
 using std::shared_ptr;
 
-class Car : public Process {
+class Car : public simcpp::Process {
 public:
-  Car(shared_ptr<Simulation> sim) : Process(sim) {}
+  Car(shared_ptr<simcpp::Simulation> sim) : Process(sim) {}
 
   virtual bool Run() override {
     PT_BEGIN();
@@ -20,7 +20,7 @@ public:
 };
 
 int main() {
-  auto sim = Simulation::create();
+  auto sim = simcpp::Simulation::create();
   sim->start_process<Car>();
   sim->run();
 

--- a/example-minimal.cpp
+++ b/example-minimal.cpp
@@ -1,4 +1,7 @@
 #include "simcpp.h"
+
+#include <cstdio>
+
 using std::shared_ptr;
 
 class Car : public Process {

--- a/example-minimal.cpp
+++ b/example-minimal.cpp
@@ -9,6 +9,8 @@ public:
   explicit Car(simcpp::SimulationPtr sim) : Process(sim) {}
 
   bool Run() override {
+    auto sim = this->sim.lock();
+
     PT_BEGIN();
 
     printf("Car running at %g.\n", sim->get_now());

--- a/example-twocars.cpp
+++ b/example-twocars.cpp
@@ -5,7 +5,7 @@
 
 class Car : public simcpp::Process {
 public:
-  explicit Car(simcpp::SimulationPtr sim, string name)
+  explicit Car(simcpp::SimulationPtr sim, std::string name)
       : Process(sim), target_time(sim->get_now() + 100.0), name(name) {}
 
   bool Run() override {

--- a/example-twocars.cpp
+++ b/example-twocars.cpp
@@ -15,7 +15,8 @@ private:
 public:
   Car(shared_ptr<Simulation> sim, string name)
       : Process(sim), target_time(sim->get_now() + 100.0), name(name) {}
-  virtual bool Run() {
+
+  virtual bool Run() override {
     PT_BEGIN();
     while (!this->finished) {
       PROC_WAIT_FOR(sim->timeout(5.0));
@@ -30,7 +31,7 @@ public:
 class TwoCars : public Process {
 public:
   TwoCars(shared_ptr<Simulation> sim) : Process(sim) {}
-  virtual bool Run() {
+  virtual bool Run() override {
     PT_BEGIN();
 
     printf("Starting car C1.\n");

--- a/example-twocars.cpp
+++ b/example-twocars.cpp
@@ -3,9 +3,6 @@
 
 #include "simcpp.h"
 
-using std::shared_ptr;
-using std::string;
-
 class Car : public simcpp::Process {
 public:
   explicit Car(simcpp::SimulationPtr sim, string name)
@@ -27,7 +24,7 @@ public:
 private:
   bool finished = false;
   double target_time;
-  string name;
+  std::string name;
 };
 
 class TwoCars : public simcpp::Process {

--- a/example-twocars.cpp
+++ b/example-twocars.cpp
@@ -13,7 +13,7 @@ private:
   string name;
 
 public:
-  Car(shared_ptr<simcpp::Simulation> sim, string name)
+  Car(simcpp::SimulationPtr sim, string name)
       : Process(sim), target_time(sim->get_now() + 100.0), name(name) {}
 
   virtual bool Run() override {
@@ -30,7 +30,7 @@ public:
 
 class TwoCars : public simcpp::Process {
 public:
-  TwoCars(shared_ptr<simcpp::Simulation> sim) : Process(sim) {}
+  TwoCars(simcpp::SimulationPtr sim) : Process(sim) {}
   virtual bool Run() override {
     PT_BEGIN();
 

--- a/example-twocars.cpp
+++ b/example-twocars.cpp
@@ -12,14 +12,15 @@ public:
       : Process(sim), target_time(sim->get_now() + 100.0), name(name) {}
 
   bool Run() override {
+    auto sim = this->sim.lock();
+
     PT_BEGIN();
-    while (!this->finished) {
+
+    while (sim->get_now() < target_time) {
       PROC_WAIT_FOR(sim->timeout(5.0));
-      printf("Car %s running at %g.\n", this->name.c_str(), sim->get_now());
-      if (sim->get_now() >= this->target_time) {
-        this->finished = true;
-      }
+      printf("Car %s running at %g.\n", name.c_str(), sim->get_now());
     }
+
     PT_END();
   }
 
@@ -34,6 +35,8 @@ public:
   explicit TwoCars(simcpp::SimulationPtr sim) : Process(sim) {}
 
   bool Run() override {
+    auto sim = this->sim.lock();
+
     PT_BEGIN();
 
     printf("Starting car C1.\n");

--- a/example-twocars.cpp
+++ b/example-twocars.cpp
@@ -1,37 +1,39 @@
-#include "simcpp.h"
-
 #include <cstdio>
 #include <string>
+
+#include "simcpp.h"
 
 using std::shared_ptr;
 using std::string;
 
 class Car : public simcpp::Process {
-private:
-  bool finished = false;
-  double target_time;
-  string name;
-
 public:
-  Car(simcpp::SimulationPtr sim, string name)
+  explicit Car(simcpp::SimulationPtr sim, string name)
       : Process(sim), target_time(sim->get_now() + 100.0), name(name) {}
 
-  virtual bool Run() override {
+  bool Run() override {
     PT_BEGIN();
     while (!this->finished) {
       PROC_WAIT_FOR(sim->timeout(5.0));
       printf("Car %s running at %g.\n", this->name.c_str(), sim->get_now());
-      if (sim->get_now() >= this->target_time)
+      if (sim->get_now() >= this->target_time) {
         this->finished = true;
+      }
     }
     PT_END();
   }
+
+private:
+  bool finished = false;
+  double target_time;
+  string name;
 };
 
 class TwoCars : public simcpp::Process {
 public:
-  TwoCars(simcpp::SimulationPtr sim) : Process(sim) {}
-  virtual bool Run() override {
+  explicit TwoCars(simcpp::SimulationPtr sim) : Process(sim) {}
+
+  bool Run() override {
     PT_BEGIN();
 
     printf("Starting car C1.\n");

--- a/example-twocars.cpp
+++ b/example-twocars.cpp
@@ -6,14 +6,14 @@
 using std::shared_ptr;
 using std::string;
 
-class Car : public Process {
+class Car : public simcpp::Process {
 private:
   bool finished = false;
   double target_time;
   string name;
 
 public:
-  Car(shared_ptr<Simulation> sim, string name)
+  Car(shared_ptr<simcpp::Simulation> sim, string name)
       : Process(sim), target_time(sim->get_now() + 100.0), name(name) {}
 
   virtual bool Run() override {
@@ -28,9 +28,9 @@ public:
   }
 };
 
-class TwoCars : public Process {
+class TwoCars : public simcpp::Process {
 public:
-  TwoCars(shared_ptr<Simulation> sim) : Process(sim) {}
+  TwoCars(shared_ptr<simcpp::Simulation> sim) : Process(sim) {}
   virtual bool Run() override {
     PT_BEGIN();
 
@@ -47,7 +47,7 @@ public:
 };
 
 int main() {
-  auto sim = Simulation::create();
+  auto sim = simcpp::Simulation::create();
   sim->start_process<TwoCars>();
   sim->advance_by(10000);
 

--- a/example-twocars.cpp
+++ b/example-twocars.cpp
@@ -1,5 +1,8 @@
 #include "simcpp.h"
+
+#include <cstdio>
 #include <string>
+
 using std::shared_ptr;
 using std::string;
 

--- a/simcpp.cpp
+++ b/simcpp.cpp
@@ -98,9 +98,9 @@ void Simulation::advance_by(double duration) {
   now = target;
 }
 
-void Simulation::advance_to(shared_ptr<Process> process) {
-  // TODO how to handle process abort?
-  while (process->is_pending() && has_next()) {
+void Simulation::advance_to(shared_ptr<Event> event) {
+  // TODO how to handle event abort?
+  while (event->is_pending() && has_next()) {
     step();
   }
 }

--- a/simcpp.cpp
+++ b/simcpp.cpp
@@ -34,6 +34,15 @@ shared_ptr<Event> Simulation::timeout(double delay) {
 }
 
 shared_ptr<Event>
+Simulation::any_of(std::initializer_list<shared_ptr<Event>> events) {
+  auto process = start_process<AnyOf>();
+  for (auto &event : events) {
+    event->add_handler(process);
+  }
+  return process;
+}
+
+shared_ptr<Event>
 Simulation::all_of(std::initializer_list<shared_ptr<Event>> events) {
   return start_process<AllOf>(events);
 }
@@ -169,12 +178,7 @@ shared_ptr<Process> Process::shared_from_this() {
 
 /* AnyOf */
 
-AnyOf::AnyOf(shared_ptr<Simulation> sim, vector<shared_ptr<Event>> events)
-    : Process(sim) {
-  for (auto &event : events) {
-    event->add_handler(shared_from_this());
-  }
-}
+AnyOf::AnyOf(shared_ptr<Simulation> sim) : Process(sim) {}
 
 bool AnyOf::Run() {
   PT_BEGIN();

--- a/simcpp.cpp
+++ b/simcpp.cpp
@@ -33,6 +33,11 @@ shared_ptr<Event> Simulation::timeout(double delay) {
   return event;
 }
 
+shared_ptr<Event>
+Simulation::all_of(std::initializer_list<shared_ptr<Event>> events) {
+  return start_process<AllOf>(events);
+}
+
 shared_ptr<Event> Simulation::schedule(shared_ptr<Event> event,
                                        double delay /* = 0.0 */) {
   queued_events.emplace(now + delay, next_id++, event);

--- a/simcpp.cpp
+++ b/simcpp.cpp
@@ -140,7 +140,7 @@ void Event::trigger() {
   }
 
   sim->schedule(shared_from_this());
-  value = 1;
+  state = 1;
 }
 
 void Event::abort() {
@@ -149,7 +149,7 @@ void Event::abort() {
     return;
   }
 
-  value = 2;
+  state = 2;
   Aborted();
 }
 
@@ -158,22 +158,22 @@ void Event::fire() {
   auto listeners = std::move(this->listeners);
 
   this->listeners = nullptr;
-  value = 1;
+  state = 1;
 
   for (auto proc : *listeners) {
     proc->resume();
   }
 }
 
-bool Event::is_pending() { return value == -1; }
+bool Event::is_pending() { return state == -1; }
 
-bool Event::is_triggered() { return value == 1; }
+bool Event::is_triggered() { return state == 1; }
 
 bool Event::is_processed() { return listeners == nullptr; }
 
-bool Event::is_aborted() { return value == 2; }
+bool Event::is_aborted() { return state == 2; }
 
-int Event::get_value() { return value; }
+int Event::get_value() { return state; }
 
 void Event::Aborted(){};
 

--- a/simcpp.cpp
+++ b/simcpp.cpp
@@ -83,11 +83,12 @@ void Simulation::advance_by(simtime duration) {
   now = target;
 }
 
-void Simulation::advance_to(EventPtr event) {
-  // TODO how to handle event abort?
+bool Simulation::advance_to(EventPtr event) {
   while (event->is_pending() && has_next()) {
     step();
   }
+
+  return event->is_triggered();
 }
 
 void Simulation::run() {
@@ -130,32 +131,33 @@ bool Event::add_handler(ProcessPtr process) {
   return true;
 }
 
-void Event::trigger() {
+bool Event::trigger() {
   if (!is_pending()) {
-    // TODO handle differently?
-    return;
+    return false;
   }
 
   auto sim = this->sim.lock();
   sim->schedule(shared_from_this());
   state = State::Triggered;
+
+  return true;
 }
 
-void Event::abort() {
+bool Event::abort() {
   if (!is_pending()) {
-    // TODO handle differently?
-    return;
+    return false;
   }
 
   state = State::Aborted;
   listeners.clear();
 
   Aborted();
+
+  return true;
 }
 
 void Event::fire() {
   if (is_aborted() || is_processed()) {
-    // TODO handle differently?
     return;
   }
 

--- a/simcpp.cpp
+++ b/simcpp.cpp
@@ -1,5 +1,7 @@
 #include "simcpp.h"
 
+#include <utility>
+
 namespace simcpp {
 
 /* Simulation */
@@ -171,7 +173,7 @@ bool Event::is_aborted() { return state == State::Aborted; }
 
 Event::State Event::get_state() { return state; }
 
-void Event::Aborted(){};
+void Event::Aborted() {}
 
 /* Process */
 

--- a/simcpp.cpp
+++ b/simcpp.cpp
@@ -1,7 +1,5 @@
 #include "simcpp.h"
 
-#include <utility>
-
 namespace simcpp {
 
 /* Simulation */

--- a/simcpp.cpp
+++ b/simcpp.cpp
@@ -137,6 +137,7 @@ void Event::trigger() {
     return;
   }
 
+  auto sim = this->sim.lock();
   sim->schedule(shared_from_this());
   state = State::Triggered;
 }

--- a/simcpp.cpp
+++ b/simcpp.cpp
@@ -48,9 +48,6 @@ bool Simulation::step() {
   queued_events.pop();
   now = queued_event.time;
   auto event = queued_event.event;
-  // TODO Does this keep the shared pointer in scope, making the
-  // automatic memory management useless?
-  // TODO Is this whole approach limited by the stack size?
   event->fire();
   return true;
 }

--- a/simcpp.cpp
+++ b/simcpp.cpp
@@ -152,7 +152,10 @@ void Event::abort() {
 }
 
 void Event::fire() {
-  // TODO what if already fired? E.g. due to triggering a timeout event
+  if (is_aborted() || is_processed()) {
+    return;
+  }
+
   auto listeners = std::move(this->listeners);
 
   this->listeners = nullptr;

--- a/simcpp.cpp
+++ b/simcpp.cpp
@@ -140,7 +140,7 @@ void Event::trigger() {
   }
 
   sim->schedule(shared_from_this());
-  state = 1;
+  state = State::Triggered;
 }
 
 void Event::abort() {
@@ -149,7 +149,7 @@ void Event::abort() {
     return;
   }
 
-  state = 2;
+  state = State::Aborted;
   Aborted();
 }
 
@@ -158,22 +158,22 @@ void Event::fire() {
   auto listeners = std::move(this->listeners);
 
   this->listeners = nullptr;
-  state = 1;
+  state = State::Triggered;
 
   for (auto proc : *listeners) {
     proc->resume();
   }
 }
 
-bool Event::is_pending() { return state == -1; }
+bool Event::is_pending() { return state == State::Pending; }
 
-bool Event::is_triggered() { return state == 1; }
+bool Event::is_triggered() { return state == State::Triggered; }
 
 bool Event::is_processed() { return listeners == nullptr; }
 
-bool Event::is_aborted() { return state == 2; }
+bool Event::is_aborted() { return state == State::Aborted; }
 
-int Event::get_value() { return state; }
+Event::State Event::get_state() { return state; }
 
 void Event::Aborted(){};
 

--- a/simcpp.cpp
+++ b/simcpp.cpp
@@ -1,19 +1,5 @@
 #include "simcpp.h"
 
-/* Simulation::QueuedEvent */
-
-Simulation::QueuedEvent::QueuedEvent(double time, size_t id,
-                                     shared_ptr<Event> event)
-    : time(time), id(id), event(event) {}
-
-bool Simulation::QueuedEvent::operator<(const QueuedEvent &other) const {
-  if (time != other.time) {
-    return time > other.time;
-  }
-
-  return id > other.id;
-}
-
 /* Simulation */
 
 shared_ptr<Simulation> Simulation::create() {
@@ -115,6 +101,20 @@ double Simulation::get_now() { return now; }
 bool Simulation::has_next() { return !queued_events.empty(); }
 
 double Simulation::peek_next_time() { return queued_events.top().time; }
+
+/* Simulation::QueuedEvent */
+
+Simulation::QueuedEvent::QueuedEvent(double time, size_t id,
+                                     shared_ptr<Event> event)
+    : time(time), id(id), event(event) {}
+
+bool Simulation::QueuedEvent::operator<(const QueuedEvent &other) const {
+  if (time != other.time) {
+    return time > other.time;
+  }
+
+  return id > other.id;
+}
 
 /* Event */
 

--- a/simcpp.cpp
+++ b/simcpp.cpp
@@ -1,5 +1,7 @@
 #include "simcpp.h"
 
+namespace simcpp {
+
 /* Simulation */
 
 shared_ptr<Simulation> Simulation::create() {
@@ -212,3 +214,5 @@ bool Condition::Run() {
   }
   PT_END();
 }
+
+} // namespace simcpp

--- a/simcpp.cpp
+++ b/simcpp.cpp
@@ -19,7 +19,7 @@ EventPtr Simulation::event() {
   return std::make_shared<Event>(shared_from_this());
 }
 
-EventPtr Simulation::timeout(double delay) {
+EventPtr Simulation::timeout(simtime delay) {
   auto event = this->event();
   schedule(event, delay);
   return event;
@@ -56,7 +56,7 @@ EventPtr Simulation::all_of(std::initializer_list<EventPtr> events) {
   return process;
 }
 
-EventPtr Simulation::schedule(EventPtr event, double delay /* = 0.0 */) {
+EventPtr Simulation::schedule(EventPtr event, simtime delay /* = 0.0 */) {
   queued_events.emplace(now + delay, next_id, event);
   ++next_id;
   return event;
@@ -75,8 +75,8 @@ bool Simulation::step() {
   return true;
 }
 
-void Simulation::advance_by(double duration) {
-  double target = now + duration;
+void Simulation::advance_by(simtime duration) {
+  simtime target = now + duration;
   while (has_next() && peek_next_time() <= target) {
     step();
   }
@@ -95,15 +95,15 @@ void Simulation::run() {
   }
 }
 
-double Simulation::get_now() { return now; }
+simtime Simulation::get_now() { return now; }
 
 bool Simulation::has_next() { return !queued_events.empty(); }
 
-double Simulation::peek_next_time() { return queued_events.top().time; }
+simtime Simulation::peek_next_time() { return queued_events.top().time; }
 
 /* Simulation::QueuedEvent */
 
-Simulation::QueuedEvent::QueuedEvent(double time, size_t id, EventPtr event)
+Simulation::QueuedEvent::QueuedEvent(simtime time, size_t id, EventPtr event)
     : time(time), id(id), event(event) {}
 
 bool Simulation::QueuedEvent::operator<(const QueuedEvent &other) const {

--- a/simcpp.cpp
+++ b/simcpp.cpp
@@ -186,10 +186,8 @@ AllOf::AllOf(shared_ptr<Simulation> sim, vector<shared_ptr<Event>> events)
 bool AllOf::Run() {
   PT_BEGIN();
   while (i < events.size()) {
-    if (!events[i]->is_triggered()) {
-      PROC_WAIT_FOR(events[i]);
-      i++;
-    }
+    PROC_WAIT_FOR(events[i]);
+    i++;
   }
   PT_END();
 }

--- a/simcpp.cpp
+++ b/simcpp.cpp
@@ -1,0 +1,175 @@
+#include "simcpp.h"
+
+/* Simulation::QueuedEvent */
+
+Simulation::QueuedEvent::QueuedEvent(double time, size_t id,
+                                     shared_ptr<Event> event)
+    : time(time), id(id), event(event) {}
+
+bool Simulation::QueuedEvent::operator<(const QueuedEvent &other) const {
+  if (time != other.time) {
+    return time > other.time;
+  }
+
+  return id > other.id;
+}
+
+/* Simulation */
+
+shared_ptr<Simulation> Simulation::create() {
+  return std::make_shared<Simulation>();
+}
+
+shared_ptr<Process> Simulation::run_process(shared_ptr<Process> process) {
+  auto event = std::make_shared<Event>(shared_from_this());
+  event->add_handler(process);
+  schedule(event);
+  return process;
+}
+
+shared_ptr<Event> Simulation::timeout(double delay) {
+  auto event = std::make_shared<Event>(shared_from_this());
+  schedule(event, delay);
+  return event;
+}
+
+shared_ptr<Event> Simulation::schedule(shared_ptr<Event> event,
+                                       double delay /* = 0.0 */) {
+  queued_events.emplace(now + delay, next_id++, event);
+  return event;
+}
+
+bool Simulation::step() {
+  if (queued_events.empty()) {
+    return false;
+  }
+
+  auto queued_event = queued_events.top();
+  queued_events.pop();
+  now = queued_event.time;
+  auto event = queued_event.event;
+  // TODO Does this keep the shared pointer in scope, making the
+  // automatic memory management useless?
+  // TODO Is this whole approach limited by the stack size?
+  event->fire();
+  return true;
+}
+
+void Simulation::advance_by(double duration) {
+  double target = now + duration;
+  while (has_next() && peek_next_time() <= target) {
+    step();
+  }
+  now = target;
+}
+
+void Simulation::advance_to(shared_ptr<Process> process) {
+  while (!process->is_triggered() && has_next()) {
+    step();
+  }
+}
+
+void Simulation::run() {
+  while (step()) {
+  }
+}
+
+double Simulation::get_now() { return now; }
+
+bool Simulation::has_next() { return !queued_events.empty(); }
+
+double Simulation::peek_next_time() { return queued_events.top().time; }
+
+/* Event */
+
+Event::Event(shared_ptr<Simulation> sim)
+    : listeners(new vector<shared_ptr<Process>>()), sim(sim) {}
+
+bool Event::add_handler(shared_ptr<Process> process) {
+  if (is_processed()) {
+    return false;
+  }
+
+  listeners->push_back(process);
+  return true;
+}
+
+bool Event::is_processed() { return listeners == nullptr; }
+
+int Event::get_value() { return value; }
+
+void Event::fire() {
+  auto listeners = std::move(this->listeners);
+
+  this->listeners = nullptr;
+  value = 0;
+
+  for (auto proc : *listeners) {
+    proc->resume();
+  }
+}
+
+bool Event::is_triggered() { return value != -1; }
+
+bool Event::is_success() { return value == 1; }
+
+bool Event::is_failed() { return value == 2; }
+
+/* Process */
+
+Process::Process(shared_ptr<Simulation> sim) : Event(sim), Protothread() {}
+
+void Process::resume() {
+  // Is the process already finished?
+  if (is_triggered()) {
+    return;
+  }
+
+  bool run = Run();
+
+  // Did the process finish now?
+  if (!run) {
+    // Process finished
+    value = 1;
+    sim->schedule(shared_from_this());
+  }
+}
+
+void Process::abort() {
+  value = 2; //?
+  Aborted();
+}
+
+void Process::Aborted(){};
+
+/* AnyOf */
+
+AnyOf::AnyOf(shared_ptr<Simulation> sim, vector<shared_ptr<Event>> events)
+    : Process(sim) {
+  for (auto &event : events) {
+    event->add_handler(shared_from_this());
+  }
+}
+
+bool AnyOf::Run() {
+  PT_BEGIN();
+  PT_YIELD();
+  // Any time we get called back, we are finished.
+  PT_END();
+}
+
+/* AllOf */
+
+AllOf::AllOf(shared_ptr<Simulation> sim, vector<shared_ptr<Event>> events)
+    : Process(sim), events(events) {}
+
+bool AllOf::Run() {
+  PT_BEGIN();
+  while (i < events.size()) {
+    if (!events[i]->is_triggered()) {
+      PROC_WAIT_FOR(events[i]);
+      i++;
+    }
+  }
+  PT_END();
+}

--- a/simcpp.cpp
+++ b/simcpp.cpp
@@ -21,14 +21,18 @@ shared_ptr<Simulation> Simulation::create() {
 }
 
 shared_ptr<Process> Simulation::run_process(shared_ptr<Process> process) {
-  auto event = std::make_shared<Event>(shared_from_this());
+  auto event = this->event();
   event->add_handler(process);
   schedule(event);
   return process;
 }
 
+shared_ptr<Event> Simulation::event() {
+  return std::make_shared<Event>(shared_from_this());
+}
+
 shared_ptr<Event> Simulation::timeout(double delay) {
-  auto event = std::make_shared<Event>(shared_from_this());
+  auto event = this->event();
   schedule(event, delay);
   return event;
 }

--- a/simcpp.cpp
+++ b/simcpp.cpp
@@ -153,6 +153,7 @@ void Event::abort() {
 
 void Event::fire() {
   if (is_aborted() || is_processed()) {
+    // TODO handle differently?
     return;
   }
 

--- a/simcpp.h
+++ b/simcpp.h
@@ -58,7 +58,7 @@ public:
 
   void advance_by(double duration);
 
-  void advance_to(shared_ptr<Process> process);
+  void advance_to(shared_ptr<Event> event);
 
   void run();
 

--- a/simcpp.h
+++ b/simcpp.h
@@ -83,7 +83,7 @@ private:
 
 class Event : public std::enable_shared_from_this<Event> {
 public:
-  enum class State { Pending, Triggered, Aborted };
+  enum class State { Pending, Triggered, Processed, Aborted };
 
   explicit Event(SimulationPtr sim);
 
@@ -112,7 +112,7 @@ protected:
 
 private:
   State state = State::Pending;
-  std::unique_ptr<std::vector<ProcessPtr>> listeners;
+  std::vector<ProcessPtr> listeners = {};
 };
 
 class Process : public Event, public Protothread {

--- a/simcpp.h
+++ b/simcpp.h
@@ -68,43 +68,45 @@ private:
   double peek_next_time();
 };
 
-class Event {
-private:
-  unique_ptr<vector<shared_ptr<Process>>> listeners;
-
-protected:
-  int value = -1;
-  shared_ptr<Simulation> sim;
-
+class Event : public std::enable_shared_from_this<Event> {
 public:
   Event(shared_ptr<Simulation> sim);
 
   bool add_handler(shared_ptr<Process> process);
 
+  void trigger();
+
+  void abort();
+
+  void fire();
+
+  bool is_pending();
+
+  bool is_triggered();
+
+  bool is_aborted();
+
   bool is_processed();
 
   int get_value();
 
-  void fire();
+  virtual void Aborted();
 
-  bool is_triggered();
+protected:
+  shared_ptr<Simulation> sim;
 
-  bool is_success();
-
-  bool is_failed();
+private:
+  int value = -1;
+  unique_ptr<vector<shared_ptr<Process>>> listeners;
 };
 
-class Process : public Event,
-                public Protothread,
-                public std::enable_shared_from_this<Process> {
+class Process : public Event, public Protothread {
 public:
   Process(shared_ptr<Simulation> sim);
 
   void resume();
 
-  void abort();
-
-  virtual void Aborted();
+  shared_ptr<Process> shared_from_this();
 };
 
 class AnyOf : public Process {

--- a/simcpp.h
+++ b/simcpp.h
@@ -46,6 +46,8 @@ public:
 
   shared_ptr<Event> timeout(double delay);
 
+  shared_ptr<Event> all_of(std::initializer_list<shared_ptr<Event>> events);
+
   shared_ptr<Event> schedule(shared_ptr<Event> event, double delay = 0.0);
 
   bool step();

--- a/simcpp.h
+++ b/simcpp.h
@@ -16,6 +16,8 @@
 
 namespace simcpp {
 
+using simtime = double;
+
 class Event;
 using EventPtr = std::shared_ptr<Event>;
 
@@ -37,41 +39,41 @@ public:
 
   EventPtr event();
 
-  EventPtr timeout(double delay);
+  EventPtr timeout(simtime delay);
 
   EventPtr any_of(std::initializer_list<EventPtr> events);
 
   EventPtr all_of(std::initializer_list<EventPtr> events);
 
-  EventPtr schedule(EventPtr event, double delay = 0.0);
+  EventPtr schedule(EventPtr event, simtime delay = 0.0);
 
   bool step();
 
-  void advance_by(double duration);
+  void advance_by(simtime duration);
 
   void advance_to(EventPtr event);
 
   void run();
 
-  double get_now();
+  simtime get_now();
 
   bool has_next();
 
-  double peek_next_time();
+  simtime peek_next_time();
 
 private:
   class QueuedEvent {
   public:
-    double time;
+    simtime time;
     size_t id;
     EventPtr event;
 
-    QueuedEvent(double time, size_t id, EventPtr event);
+    QueuedEvent(simtime time, size_t id, EventPtr event);
 
     bool operator<(const QueuedEvent &other) const;
   };
 
-  double now = 0.0;
+  simtime now = 0.0;
   size_t next_id = 0;
   std::priority_queue<QueuedEvent> queued_events;
 };

--- a/simcpp.h
+++ b/simcpp.h
@@ -24,17 +24,6 @@ class Process;
 
 class Simulation : public std::enable_shared_from_this<Simulation> {
 public:
-  class QueuedEvent {
-  public:
-    double time;
-    size_t id;
-    shared_ptr<Event> event;
-
-    QueuedEvent(double time, size_t id, shared_ptr<Event> event);
-
-    bool operator<(const QueuedEvent &other) const;
-  };
-
   static shared_ptr<Simulation> create();
 
   template <class T, class... Args>
@@ -65,6 +54,17 @@ public:
   double get_now();
 
 private:
+  class QueuedEvent {
+  public:
+    double time;
+    size_t id;
+    shared_ptr<Event> event;
+
+    QueuedEvent(double time, size_t id, shared_ptr<Event> event);
+
+    bool operator<(const QueuedEvent &other) const;
+  };
+
   double now = 0.0;
   size_t next_id = 0;
   priority_queue<QueuedEvent> queued_events;

--- a/simcpp.h
+++ b/simcpp.h
@@ -76,6 +76,8 @@ private:
 
 class Event : public std::enable_shared_from_this<Event> {
 public:
+  enum class State { Pending, Triggered, Aborted };
+
   Event(shared_ptr<Simulation> sim);
 
   bool add_handler(shared_ptr<Process> process);
@@ -94,7 +96,7 @@ public:
 
   bool is_processed();
 
-  int get_value();
+  State get_state();
 
   virtual void Aborted();
 
@@ -102,7 +104,7 @@ protected:
   shared_ptr<Simulation> sim;
 
 private:
-  int state = -1;
+  State state = State::Pending;
   unique_ptr<vector<shared_ptr<Process>>> listeners;
 };
 

--- a/simcpp.h
+++ b/simcpp.h
@@ -34,8 +34,10 @@ public:
         : time(time), id(id), event(event) {}
 
     bool operator<(const QueuedEvent &other) const {
-      if (time != other.time)
+      if (time != other.time) {
         return time > other.time;
+      }
+
       return id > other.id;
     }
   };
@@ -75,8 +77,8 @@ public:
   void advance_to(shared_ptr<Process> process);
 
   void run() {
-    while (step())
-      ;
+    while (step()) {
+    }
   }
   double get_now() { return now; }
 };
@@ -128,8 +130,9 @@ void Process::abort() {
 
 void Process::resume() {
   // Is the process already finished?
-  if (is_triggered())
+  if (is_triggered()) {
     return;
+  }
 
   bool run = Run();
 
@@ -191,8 +194,9 @@ class AnyOf : public Process {
 public:
   AnyOf(shared_ptr<Simulation> sim, vector<shared_ptr<Event>> events)
       : Process(sim) {
-    for (auto &event : events)
+    for (auto &event : events) {
       event->add_handler(shared_from_this());
+    }
   }
   virtual bool Run() override {
     PT_BEGIN();

--- a/simcpp.h
+++ b/simcpp.h
@@ -20,9 +20,11 @@ using simtime = double;
 
 class Event;
 using EventPtr = std::shared_ptr<Event>;
+using EventWeakPtr = std::weak_ptr<Event>;
 
 class Process;
 using ProcessPtr = std::shared_ptr<Process>;
+using ProcessWeakPtr = std::weak_ptr<Process>;
 
 class Simulation;
 using SimulationPtr = std::shared_ptr<Simulation>;

--- a/simcpp.h
+++ b/simcpp.h
@@ -113,21 +113,14 @@ public:
   shared_ptr<Process> shared_from_this();
 };
 
-class AnyOf : public Process {
+class Condition : public Process {
 public:
-  AnyOf(shared_ptr<Simulation> sim);
+  Condition(shared_ptr<Simulation> sim, int n);
 
   virtual bool Run() override;
-};
 
-class AllOf : public Process {
-  size_t i = 0;
-  vector<shared_ptr<Event>> events;
-
-public:
-  AllOf(shared_ptr<Simulation> sim, vector<shared_ptr<Event>> events);
-
-  virtual bool Run() override;
+private:
+  int n;
 };
 
 #endif

--- a/simcpp.h
+++ b/simcpp.h
@@ -102,7 +102,7 @@ protected:
   shared_ptr<Simulation> sim;
 
 private:
-  int value = -1;
+  int state = -1;
   unique_ptr<vector<shared_ptr<Process>>> listeners;
 };
 

--- a/simcpp.h
+++ b/simcpp.h
@@ -54,7 +54,7 @@ public:
 
   void advance_by(simtime duration);
 
-  void advance_to(EventPtr event);
+  bool advance_to(EventPtr event);
 
   void run();
 
@@ -89,9 +89,9 @@ public:
 
   bool add_handler(ProcessPtr process);
 
-  void trigger();
+  bool trigger();
 
-  void abort();
+  bool abort();
 
   void fire();
 

--- a/simcpp.h
+++ b/simcpp.h
@@ -1,11 +1,11 @@
-#ifndef __SIMCPP_H
-#define __SIMCPP_H
-
-#include "protothread.h"
+#ifndef SIMCPP_H_
+#define SIMCPP_H_
 
 #include <memory>
 #include <queue>
 #include <vector>
+
+#include "protothread.h"
 
 #define PROC_WAIT_FOR(event)                                                   \
   do {                                                                         \
@@ -80,7 +80,7 @@ class Event : public std::enable_shared_from_this<Event> {
 public:
   enum class State { Pending, Triggered, Aborted };
 
-  Event(SimulationPtr sim);
+  explicit Event(SimulationPtr sim);
 
   bool add_handler(ProcessPtr process);
 
@@ -112,7 +112,7 @@ private:
 
 class Process : public Event, public Protothread {
 public:
-  Process(SimulationPtr sim);
+  explicit Process(SimulationPtr sim);
 
   void resume();
 
@@ -123,7 +123,7 @@ class Condition : public Process {
 public:
   Condition(SimulationPtr sim, int n);
 
-  virtual bool Run() override;
+  bool Run() override;
 
 private:
   int n;
@@ -131,4 +131,4 @@ private:
 
 } // namespace simcpp
 
-#endif
+#endif // SIMCPP_H_

--- a/simcpp.h
+++ b/simcpp.h
@@ -53,6 +53,10 @@ public:
 
   double get_now();
 
+  bool has_next();
+
+  double peek_next_time();
+
 private:
   class QueuedEvent {
   public:
@@ -68,10 +72,6 @@ private:
   double now = 0.0;
   size_t next_id = 0;
   priority_queue<QueuedEvent> queued_events;
-
-  bool has_next();
-
-  double peek_next_time();
 };
 
 class Event : public std::enable_shared_from_this<Event> {

--- a/simcpp.h
+++ b/simcpp.h
@@ -46,24 +46,17 @@ public:
     return std::make_shared<Simulation>();
   }
 
-  shared_ptr<Process> run_process(shared_ptr<Process> process);
-
   template <class T, class... Args>
   shared_ptr<Process> start_process(Args &&...args) {
     return run_process(std::make_shared<T>(shared_from_this(), args...));
   }
 
+  shared_ptr<Process> run_process(shared_ptr<Process> process);
+
   shared_ptr<Event> timeout(double delay);
 
-private:
-  double now = 0.0;
-  priority_queue<QueuedEvent> queued_events;
-  size_t next_id = 0;
-  bool has_next() { return !queued_events.empty(); }
-  double peek_next_time() { return queued_events.top().time; }
-
-public:
   shared_ptr<Event> schedule(shared_ptr<Event> event, double delay = 0.0);
+
   bool step();
 
   void advance_by(double duration) {
@@ -80,7 +73,17 @@ public:
     while (step()) {
     }
   }
+
   double get_now() { return now; }
+
+private:
+  double now = 0.0;
+  priority_queue<QueuedEvent> queued_events;
+  size_t next_id = 0;
+
+  bool has_next() { return !queued_events.empty(); }
+
+  double peek_next_time() { return queued_events.top().time; }
 };
 
 class Event {
@@ -105,11 +108,15 @@ public:
   }
 
   bool is_processed() { return listeners == nullptr; }
+
   int get_value() { return value; }
+
   void fire();
 
   bool is_triggered() { return value != -1; }
+
   bool is_success() { return value == 1; }
+
   bool is_failed() { return value == 2; }
 };
 
@@ -118,8 +125,11 @@ class Process : public Event,
                 public std::enable_shared_from_this<Process> {
 public:
   Process(shared_ptr<Simulation> sim) : Event(sim), Protothread() {}
+
   void resume();
+
   void abort();
+
   virtual void Aborted(){};
 };
 

--- a/simcpp.h
+++ b/simcpp.h
@@ -46,6 +46,8 @@ public:
 
   shared_ptr<Event> timeout(double delay);
 
+  shared_ptr<Event> any_of(std::initializer_list<shared_ptr<Event>> events);
+
   shared_ptr<Event> all_of(std::initializer_list<shared_ptr<Event>> events);
 
   shared_ptr<Event> schedule(shared_ptr<Event> event, double delay = 0.0);
@@ -113,7 +115,7 @@ public:
 
 class AnyOf : public Process {
 public:
-  AnyOf(shared_ptr<Simulation> sim, vector<shared_ptr<Event>> events);
+  AnyOf(shared_ptr<Simulation> sim);
 
   virtual bool Run() override;
 };

--- a/simcpp.h
+++ b/simcpp.h
@@ -44,6 +44,8 @@ public:
 
   shared_ptr<Process> run_process(shared_ptr<Process> process);
 
+  shared_ptr<Event> event();
+
   shared_ptr<Event> timeout(double delay);
 
   shared_ptr<Event> any_of(std::initializer_list<shared_ptr<Event>> events);

--- a/simcpp.h
+++ b/simcpp.h
@@ -13,6 +13,8 @@
     }                                                                          \
   } while (0)
 
+namespace simcpp {
+
 using std::priority_queue;
 using std::shared_ptr;
 using std::unique_ptr;
@@ -126,5 +128,7 @@ public:
 private:
   int n;
 };
+
+} // namespace simcpp
 
 #endif

--- a/simcpp.h
+++ b/simcpp.h
@@ -19,29 +19,32 @@ using std::unique_ptr;
 using std::vector;
 
 class Event;
-class Process;
-class Simulation : public std::enable_shared_from_this<Simulation> {
 
+class Process;
+
+class Simulation : public std::enable_shared_from_this<Simulation> {
 public:
   class QueuedEvent {
   public:
     double time;
     size_t id;
     shared_ptr<Event> event;
-    QueuedEvent(double t, size_t id, shared_ptr<Event> e)
-        : time(t), id(id), event(e) {}
 
-    bool operator<(const QueuedEvent &b) const {
-      if (time != b.time)
-        return time > b.time;
-      return id > b.id;
+    QueuedEvent(double time, size_t id, shared_ptr<Event> event)
+        : time(time), id(id), event(event) {}
+
+    bool operator<(const QueuedEvent &other) const {
+      if (time != other.time)
+        return time > other.time;
+      return id > other.id;
     }
   };
 
   static shared_ptr<Simulation> create() {
     return std::make_shared<Simulation>();
   }
-  shared_ptr<Process> run_process(shared_ptr<Process> p);
+
+  shared_ptr<Process> run_process(shared_ptr<Process> process);
 
   template <class T, class... Args>
   shared_ptr<Process> start_process(Args &&...args) {
@@ -52,24 +55,24 @@ public:
 
 private:
   double now = 0.0;
-  priority_queue<QueuedEvent> events;
-  size_t id_counter = 0;
-  bool has_next() { return !events.empty(); }
-  double peek_next_time() { return events.top().time; }
+  priority_queue<QueuedEvent> queued_events;
+  size_t next_id = 0;
+  bool has_next() { return !queued_events.empty(); }
+  double peek_next_time() { return queued_events.top().time; }
 
 public:
-  shared_ptr<Event> schedule(shared_ptr<Event> e, double delay = 0.0);
+  shared_ptr<Event> schedule(shared_ptr<Event> event, double delay = 0.0);
   bool step();
 
-  void advance_by(double t) {
-    double target = now + t;
+  void advance_by(double duration) {
+    double target = now + duration;
     while (has_next() && peek_next_time() <= target) {
       step();
     }
     now = target;
   }
 
-  void advance_to(shared_ptr<Process> p);
+  void advance_to(shared_ptr<Process> process);
 
   void run() {
     while (step())
@@ -90,12 +93,12 @@ public:
   Event(shared_ptr<Simulation> sim)
       : listeners(new vector<shared_ptr<Process>>()), sim(sim) {}
 
-  bool add_handler(shared_ptr<Process> p) {
+  bool add_handler(shared_ptr<Process> process) {
     if (is_processed()) {
       return false;
     }
 
-    listeners->push_back(p);
+    listeners->push_back(process);
     return true;
   }
 
@@ -138,20 +141,21 @@ void Process::resume() {
   }
 }
 
-shared_ptr<Event> Simulation::schedule(shared_ptr<Event> e, double delay /* = 0 */) {
-  events.emplace(now + delay, id_counter++, e);
-  return e;
+shared_ptr<Event> Simulation::schedule(shared_ptr<Event> event,
+                                       double delay /* = 0 */) {
+  queued_events.emplace(now + delay, next_id++, event);
+  return event;
 }
 
 bool Simulation::step() {
-  if (events.empty()) {
+  if (queued_events.empty()) {
     return false;
   }
 
-  auto queuedEvent = events.top();
-  events.pop();
-  now = queuedEvent.time;
-  auto event = queuedEvent.event;
+  auto queued_event = queued_events.top();
+  queued_events.pop();
+  now = queued_event.time;
+  auto event = queued_event.event;
   // TODO Does this keep the shared pointer in scope, making the
   // automatic memory management useless?
   // TODO Is this whole approach limited by the stack size?
@@ -170,25 +174,25 @@ void Event::fire() {
   }
 }
 
-shared_ptr<Process> Simulation::run_process(shared_ptr<Process> p) {
-  auto ev = std::make_shared<Event>(shared_from_this());
-  ev->add_handler(p);
-  schedule(ev);
-  return p;
+shared_ptr<Process> Simulation::run_process(shared_ptr<Process> process) {
+  auto event = std::make_shared<Event>(shared_from_this());
+  event->add_handler(process);
+  schedule(event);
+  return process;
 }
 
 shared_ptr<Event> Simulation::timeout(double delay) {
-  auto ev = std::make_shared<Event>(shared_from_this());
-  schedule(ev, delay);
-  return ev;
+  auto event = std::make_shared<Event>(shared_from_this());
+  schedule(event, delay);
+  return event;
 }
 
 class AnyOf : public Process {
 public:
-  AnyOf(shared_ptr<Simulation> sim, vector<shared_ptr<Event>> v)
+  AnyOf(shared_ptr<Simulation> sim, vector<shared_ptr<Event>> events)
       : Process(sim) {
-    for (auto &e : v)
-      e->add_handler(shared_from_this());
+    for (auto &event : events)
+      event->add_handler(shared_from_this());
   }
   virtual bool Run() override {
     PT_BEGIN();
@@ -201,17 +205,17 @@ public:
 
 // ALLOF event
 class AllOf : public Process {
-  vector<shared_ptr<Event>> v;
+  vector<shared_ptr<Event>> events;
   size_t i = 0;
 
 public:
-  AllOf(shared_ptr<Simulation> sim, vector<shared_ptr<Event>> v)
-      : Process(sim), v(v) {}
+  AllOf(shared_ptr<Simulation> sim, vector<shared_ptr<Event>> events)
+      : Process(sim), events(events) {}
   virtual bool Run() override {
     PT_BEGIN();
-    while (i < v.size()) {
-      if (!v[i]->is_triggered()) {
-        PROC_WAIT_FOR(v[i]);
+    while (i < events.size()) {
+      if (!events[i]->is_triggered()) {
+        PROC_WAIT_FOR(events[i]);
         i++;
       }
     }
@@ -219,8 +223,8 @@ public:
   }
 };
 
-void Simulation::advance_to(shared_ptr<Process> p) {
-  while (!p->is_triggered() && has_next()) {
+void Simulation::advance_to(shared_ptr<Process> process) {
+  while (!process->is_triggered() && has_next()) {
     step();
   }
 }

--- a/simcpp.h
+++ b/simcpp.h
@@ -26,6 +26,7 @@ using ProcessPtr = std::shared_ptr<Process>;
 
 class Simulation;
 using SimulationPtr = std::shared_ptr<Simulation>;
+using SimulationWeakPtr = std::weak_ptr<Simulation>;
 
 class Simulation : public std::enable_shared_from_this<Simulation> {
 public:
@@ -105,7 +106,7 @@ public:
   virtual void Aborted();
 
 protected:
-  SimulationPtr sim;
+  SimulationWeakPtr sim;
 
 private:
   State state = State::Pending;


### PR DESCRIPTION
This pull requests includes many breaking changes. The commit messages should be explaining the changes. The main changes are:

- Rework the event system
  - Rename `Event::value` to `Event::state` and `Event::get_value` to `Event::get_state`
  - Use an enum for `Event::state`
  - Events can be pending, triggered, processed, or aborted
  - Call `Event::trigger` to trigger an event (this schedules the event to be fired immediately)
  - Call `Event::abort` to abort an event (this only sets the state and calls the virtual `Event::Aborted` method)
  - Call `Event::is_pending`, `Event::is_triggered`, `Event::is_processed`, and `Event::is_aborted` to check whether the event is in a particular state (`Event::is_triggered` is also true if the event is processed)
  - `Process` now uses the event mechanics for aborting
- Replace `AllOf` with `Simulation::all_of` and fix it (the previous implementation got into an infinite loop when waiting for an already triggered event)
- Replace `AnyOf` with `Simulation::any_of` and fix it (the previous implementation called `shared_from_this` in the constructor, which is not allowed)
- Put all classes into the `simcpp` namespace

Some questions remaining:
- [x] How to handle aborted or already processed events in `Event::fire`? Currently, the function just returns in this case.
- [x] How to handle non-pending events in `Event::abort` and `Event::trigger`? Currently, the function just returns in this case.
- [x] How to handle aborted events or an empty event queue in `Simulation::advance_to`? Currently, the function stops stepping when the event is no longer pending or the event queue is empty.

The main aspect of these questions is whether to introduce some kind of error, e.g. returning false, or throwing an exception.

Furthermore, if you do not like any of the changes I commited, I will revert them - please comment accordingly.