### PR TITLE
Minor improvements

### DIFF
--- a/protothread.h
+++ b/protothread.h
@@ -88,7 +88,9 @@ class Protothread
 public:
     // Construct a new protothread that will start from the beginning
     // of its Run() function.
-    Protothread() : _ptLine(0) { }
+    Protothread() = default;
+
+    virtual ~Protothread() = default;
 
     // Restart protothread.
     void Restart() { _ptLine = 0; }
@@ -100,7 +102,7 @@ public:
 
     // Return true if the protothread is running or waiting, false if it has
     // ended or exited.
-    bool IsRunning() { return _ptLine != LineNumberInvalid; }
+    bool IsRunning() const { return _ptLine != LineNumberInvalid; }
 
     // Run next part of protothread or return immediately if it's still
     // waiting. Return true if protothread is still running, false if it
@@ -110,14 +112,14 @@ public:
 protected:
     // Used to store a protothread's position (what Dunkels calls a
     // "local continuation").
-    typedef unsigned short LineNumber;
+    using LineNumber = unsigned short;
 
     // An invalid line number, used to mark the protothread has ended.
     static const LineNumber LineNumberInvalid = (LineNumber)(-1);
 
     // Stores the protothread's position (by storing the line number of
     // the last PT_WAIT, which is then switched on at the next Run).
-    LineNumber _ptLine;
+    LineNumber _ptLine = 0;
 };
 
 // Declare start of protothread (use at start of Run() implementation).

--- a/simcpp.cpp
+++ b/simcpp.cpp
@@ -23,7 +23,7 @@ EventPtr Simulation::timeout(simtime delay) {
 
 EventPtr Simulation::any_of(std::initializer_list<EventPtr> events) {
   int n = 1;
-  for (auto &event : events) {
+  for (const auto &event : events) {
     if (event->is_triggered()) {
       n = 0;
       break;
@@ -39,7 +39,7 @@ EventPtr Simulation::any_of(std::initializer_list<EventPtr> events) {
 
 EventPtr Simulation::all_of(std::initializer_list<EventPtr> events) {
   int n = 0;
-  for (auto &event : events) {
+  for (const auto &event : events) {
     if (!event->is_triggered()) {
       ++n;
     }
@@ -87,15 +87,14 @@ bool Simulation::advance_to(const EventPtr& event) {
 }
 
 void Simulation::run() {
-  while (step()) {
-  }
+    while (step());
 }
 
-simtime Simulation::get_now() { return now; }
+simtime Simulation::get_now() const { return now; }
 
-bool Simulation::has_next() { return !queued_events.empty(); }
+bool Simulation::has_next() const { return !queued_events.empty(); }
 
-simtime Simulation::peek_next_time() { return queued_events.top().time; }
+simtime Simulation::peek_next_time() const { return queued_events.top().time; }
 
 /* Simulation::QueuedEvent */
 

--- a/simcpp.h
+++ b/simcpp.h
@@ -171,13 +171,13 @@ public:
   void run();
 
   /// @return Current simulation time.
-  simtime get_now();
+  simtime get_now() const;
 
   /// @return Whether a scheduled event is left.
-  bool has_next();
+  bool has_next() const;
 
   /// @return Time at which the next event is scheduled.
-  simtime peek_next_time();
+  simtime peek_next_time() const;
 
 private:
   class QueuedEvent {

--- a/simcpp.h
+++ b/simcpp.h
@@ -92,7 +92,7 @@ public:
    * @param process Process to be run.
    * @param delay Delay after which to run the process.
    */
-  void run_process(ProcessPtr process, simtime delay = 0.0);
+  void run_process(const ProcessPtr& process, simtime delay = 0.0);
 
   /**
    * Construct an event.
@@ -142,7 +142,7 @@ public:
    * @param event Event instance.
    * @param delay Delay after which the event is processed.
    */
-  void schedule(EventPtr event, simtime delay = 0.0);
+  void schedule(const EventPtr& event, simtime delay = 0.0);
 
   /**
    * Process the next scheduled event.
@@ -165,7 +165,7 @@ public:
    * @return Whether the event was triggered. If no scheduled events are left or
    * the event is aborted, this is not the case.
    */
-  bool advance_to(EventPtr event);
+  bool advance_to(const EventPtr& event);
 
   /// Run the simulation until no scheduled events are left.
   void run();
@@ -186,7 +186,7 @@ private:
     size_t id;
     EventPtr event;
 
-    QueuedEvent(simtime time, size_t id, EventPtr event);
+    QueuedEvent(simtime time, size_t id, const EventPtr& event);
 
     bool operator<(const QueuedEvent &other) const;
   };
@@ -221,7 +221,7 @@ public:
    *
    * @param sim Simulation instance.
    */
-  explicit Event(SimulationPtr sim);
+  explicit Event(const SimulationPtr& sim);
 
   /**
    * Add the resume method of a process as an handler of the event.
@@ -233,7 +233,7 @@ public:
    * @param process The process to resume when the event is processed.
    * @return Whether the event was not already triggered.
    */
-  bool add_handler(ProcessPtr process);
+  bool add_handler(const ProcessPtr& process);
 
   /**
    * Add the callback as an handler of the event.
@@ -244,7 +244,7 @@ public:
    * receives the event instance as an argument.
    * @return Whether the event was not already triggered.
    */
-  bool add_handler(Handler handler);
+  bool add_handler(const Handler& handler);
 
   /**
    * Trigger the event with a delay.
@@ -274,22 +274,22 @@ public:
   void process();
 
   /// @return Whether the event is pending.
-  bool is_pending();
+  bool is_pending() const;
 
   /**
    * @return Whether the event is triggered. Also true if the event is
    * processed.
    */
-  bool is_triggered();
+  bool is_triggered() const;
 
   /// @return Whether the event is aborted.
-  bool is_aborted();
+  bool is_aborted() const;
 
   /// @return Whether the event is processed.
-  bool is_processed();
+  bool is_processed() const;
 
   /// @return Whether the event is pending.
-  State get_state();
+  State get_state() const;
 
   /// Called when the event is aborted.
   virtual void Aborted();
@@ -316,7 +316,7 @@ public:
    *
    * @param sim Simulation instance.
    */
-  explicit Process(SimulationPtr sim);
+  explicit Process(const SimulationPtr& sim);
 
   /**
    * Resumes the process.
@@ -339,7 +339,7 @@ public:
    * @param sim Simulation instance.
    * @param n Number of times the process must be resumed before it finishes.
    */
-  Condition(SimulationPtr sim, int n);
+  Condition(const SimulationPtr& sim, int n);
 
   /**
    * Wait for the given number of resumes and then finish.

--- a/simobj.h
+++ b/simobj.h
@@ -8,12 +8,12 @@ private:                                                                       \
   TYP NAM = VAL;                                                               \
                                                                                \
 public:                                                                        \
-  simcpp::EventPtr NAM##_event{std::make_shared<simcpp::Event>(env)};                          \
+  simcpp::EventPtr NAM##_event{std::make_shared<simcpp::Event>(env)};          \
   TYP get_##NAM() const { return this->NAM; }                                  \
   void set_##NAM(TYP v) {                                                      \
     this->NAM = v;                                                             \
     this->env->schedule(this->NAM##_event);                                    \
-    this->NAM##_event = std::make_shared<simcpp::Event>(env);                          \
+    this->NAM##_event = std::make_shared<simcpp::Event>(env);                  \
   }
 
 

--- a/simobj.h
+++ b/simobj.h
@@ -1,3 +1,6 @@
+#ifndef SIMOBJ_H_
+#define SIMOBJ_H_
+
 #include "simcpp.h"
 
 #define OBSERVABLE_PROPERTY(TYP, NAM, VAL)                                     \
@@ -5,24 +8,27 @@ private:                                                                       \
   TYP NAM = VAL;                                                               \
                                                                                \
 public:                                                                        \
-  shared_ptr<Event> NAM##_event = std::make_shared<Event>(env);                \
-  TYP get_##NAM() { return this->NAM; }                                        \
+  simcpp::EventPtr NAM##_event{std::make_shared<simcpp::Event>(env)};                          \
+  TYP get_##NAM() const { return this->NAM; }                                  \
   void set_##NAM(TYP v) {                                                      \
     this->NAM = v;                                                             \
     this->env->schedule(this->NAM##_event);                                    \
-    this->NAM##_event = std::make_shared<Event>(env);                          \
+    this->NAM##_event = std::make_shared<simcpp::Event>(env);                          \
   }
 
 
 namespace simcpp {
 
-    class EnvObj {
-    protected:
-        std::shared_ptr<Simulation> env;
+class EnvObj {
+protected:
+    SimulationPtr env;
 
-    public:
-        explicit EnvObj(const std::shared_ptr<Simulation>& s) : env(s) {}
-        virtual ~EnvObj() = default;
-    };
+public:
+    explicit EnvObj(const SimulationPtr& s) : env(s) {}
+    virtual ~EnvObj() = default;
+};
 
 }
+
+
+#endif

--- a/simobj.h
+++ b/simobj.h
@@ -13,10 +13,15 @@ public:                                                                        \
     this->NAM##_event = std::make_shared<Event>(env);                          \
   }
 
-class EnvObj {
-protected:
-  shared_ptr<Simulation> env;
 
-public:
-  EnvObj(shared_ptr<Simulation> s) : env(s) {}
-};
+namespace simcpp {
+
+    class EnvObj {
+    protected:
+        std::shared_ptr<Simulation> env;
+
+    public:
+        explicit EnvObj(const std::shared_ptr<Simulation>& s) : env(s) {}
+    };
+
+}

--- a/simobj.h
+++ b/simobj.h
@@ -22,6 +22,7 @@ namespace simcpp {
 
     public:
         explicit EnvObj(const std::shared_ptr<Simulation>& s) : env(s) {}
+        virtual ~EnvObj() = default;
     };
 
 }


### PR DESCRIPTION
Pass std::shared_ptr by const reference instead of value, added const specifiers for 'get' functions, added default virtual destructor for Protothread since it has a virtual pure function that is supposed to be implemented in a derived class. Moved EnvObj class in simcpp namespace and declared its constructor explicit.